### PR TITLE
Fix PHP 8.2 deprecation

### DIFF
--- a/src/AutomaticServiceProvider.php
+++ b/src/AutomaticServiceProvider.php
@@ -11,6 +11,13 @@ namespace :uc:vendor\:uc:package;
  */
 trait AutomaticServiceProvider
 {
+    /**
+     * The src directory of the add-on.
+     *
+     * @var string
+     */
+    protected string $path;
+    
     public function __construct($app)
     {
         $this->app = $app;


### PR DESCRIPTION
Dynamic properties are deprecated in PHP 8.2 and will be removed in PHP 9.0. This PR fixes a deprecation error on the `AutomaticServiceProvider` trait where the `path` property is created dynamically in the constructor, by explicitly marking it as class property.

Reference: https://wiki.php.net/rfc/deprecate_dynamic_properties

Note: I encountered this in the `backpack\pro` implementation of this skeleton, but don't have access to the private repository for PR's then ran into this repository. If you can give me access to the private repo, I'll copy this PR to there; otherwise also feel free to copy this!